### PR TITLE
feat: windows support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,10 +41,14 @@ if (packageJSON && packageJSON.engines && packageJSON.engines.yarn) {
   yarnVersion = packageJSON.engines.yarn;
 }
 
-const r = cp.spawnSync('npx', [`yarn@${yarnVersion}`], {
+const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+const r = cp.spawnSync(npxCommand, [`yarn@${yarnVersion}`], {
   cwd: process.cwd(),
   stdio: 'inherit',
 });
 if (r.status !== 0) {
+  if (r.error) {
+    console.error(r.error);
+  }
   process.exit(r.status);
 }


### PR DESCRIPTION
`uuaw` on Windows was editing the yarn.lock file, but failing to run `yarn` with the following error:
```
Error: spawnSync npx ENOENT
    at Object.spawnSync (node:internal/child_process:1119:20)
    at Object.spawnSync (node:child_process:847:24)
    at Object.<anonymous> (C:\Users\smaddock\AppData\Roaming\npm\node_modules\uuaw\src\index.js:44:14)
    at Module._compile (node:internal/modules/cjs/loader:1196:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1250:10)
    at Module.load (node:internal/modules/cjs/loader:1074:32)
    at Function.Module._load (node:internal/modules/cjs/loader:909:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:22:47 {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawnSync npx',
  path: 'npx',
  spawnargs: [ 'yarn@latest' ]
}
```

Initially I wasn't aware of the error since it wasn't being logged, but the command completed suspiciously quickly.

Some docs from node: https://nodejs.org/api/child_process.html#spawning-bat-and-cmd-files-on-windows

Alternatives are to pass in the `shell: true` option to spawnSync. However, I wasn't sure how that would affect other platforms.