### PR TITLE
fix: win32 spawn on newer node versions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ const npxCommand = process.platform === 'win32' ? 'npx.cmd' : 'npx';
 const r = cp.spawnSync(npxCommand, [`yarn@${yarnVersion}`], {
   cwd: process.cwd(),
   stdio: 'inherit',
+  shell: process.platform === 'win32',
 });
 if (r.status !== 0) {
   if (r.error) {


### PR DESCRIPTION
cp.spawn now requires `shell: true` on win32.

https://nodejs.org/en/blog/release/v20.12.2
> CVE-2024-27980 - Command injection via args parameter of child_process.spawn without shell option enabled on Windows